### PR TITLE
Train and Save TF model for all 6 gestures

### DIFF
--- a/v4_Gesture_Recognition_Training.ipynb
+++ b/v4_Gesture_Recognition_Training.ipynb
@@ -1,0 +1,829 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AI DEMO - Summit -Tensorflow Dance Move Training\n",
+    "\n",
+    "This note book should be able to run on the OCP4 Demo Cluster by simply selecting \"Cell\" and then \"Run All\" at the top of the page.\n",
+    "\n",
+    "Running this notebook will:\n",
+    "* Pull gesture data from S3\n",
+    "* Preprocess the gesture data\n",
+    "* Train a Tensorflow neural network model\n",
+    "* Save the model for serving"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import s3fs\n",
+    "import scipy.stats\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import scipy\n",
+    "from pathlib import Path\n",
+    "from datetime import datetime as dt\n",
+    "import matplotlib.pylab as plt\n",
+    "import json\n",
+    "import time\n",
+    "import os\n",
+    "\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import confusion_matrix,classification_report\n",
+    "from sklearn.preprocessing import LabelEncoder, OneHotEncoder, MinMaxScaler\n",
+    "from sklearn.decomposition import PCA\n",
+    "\n",
+    "import tensorflow as tf\n",
+    "from tensorflow import keras"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Functions to read and preprocess raw data from Open Data Hub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_raw_data(fs, path, debug=False):\n",
+    "    '''Reads raw data from S3 - not parallelized\n",
+    "    '''\n",
+    "    data = {}\n",
+    "    \n",
+    "    gestures_paths = fs.ls(path)\n",
+    "    \n",
+    "    for gesture in gestures_paths:\n",
+    "        files_to_read = fs.ls(gesture)\n",
+    "    \n",
+    "        key = gesture.split('/')[-1] \n",
+    "        data[key] = []\n",
+    "        if debug:\n",
+    "            print(key)\n",
+    "    \n",
+    "        for file in files_to_read:\n",
+    "            with fs.open(file) as f:\n",
+    "                content = json.loads(f.read())\n",
+    "            data[key].append(content)\n",
+    "    \n",
+    "    return data\n",
+    "\n",
+    "counter = 0\n",
+    "def process_crosses_data(data_crosses):\n",
+    "    '''Returns list of size N_samples and each element = tuple(index, label, acc+rot vel dataframe, rot angle dataframe)\n",
+    "    '''\n",
+    "\n",
+    "    global counter\n",
+    "    \n",
+    "    data_cross_list = []\n",
+    "    gesture = 'draw-cross'\n",
+    "\n",
+    "    for d in data_crosses: #loop over each sample\n",
+    "        acc_data = pd.DataFrame([x['acceleration'] for elem in data_crosses[d] for x in elem['motion']])\n",
+    "        acc_data.columns = ['acceleration_x', 'acceleration_y', 'acceleration_z']\n",
+    "\n",
+    "        rot_data = pd.DataFrame([x['rotationRate'] for elem in data_crosses[d] for x in elem['motion']])\n",
+    "        rot_data.columns = ['rotation_alpha', 'rotation_beta', 'rotation_gamma']\n",
+    "\n",
+    "        timestamp_data = pd.DataFrame([x['timestamp'] for elem in data_crosses[d] for x in elem['motion']])\n",
+    "        timestamp_data.columns = ['timestamp']\n",
+    "\n",
+    "        motion_df = pd.concat([acc_data, rot_data, timestamp_data], axis=1).sort_values('timestamp', ascending=True).drop('timestamp', axis=1)\n",
+    "        orientation_df = None\n",
+    "\n",
+    "        data_cross_list.append((counter, gesture, motion_df, orientation_df))\n",
+    "        counter += 1\n",
+    "        \n",
+    "    return data_cross_list\n",
+    "\n",
+    "def process_dance_data(data_dance_raw):\n",
+    "    '''Returns list of size N_samples and each element = tuple(index, label, acc+rot vel dataframe, rot angle dataframe)\n",
+    "    '''\n",
+    "\n",
+    "    #Ugly\n",
+    "    #convert appropriate data to dataframes\n",
+    "    global counter\n",
+    "    \n",
+    "    data = []\n",
+    "    #counter = 0 #counter from before\n",
+    "    for k in data_dance_raw.keys(): #loop over each dance type\n",
+    "        d = data_dance_raw[k]\n",
+    "        for example in d: #loop over each sample\n",
+    "            gesture = example['gesture']\n",
+    "\n",
+    "            motion = np.array(example['motion'])\n",
+    "            orientation = np.array(example['orientation'])\n",
+    "\n",
+    "            #process motion data\n",
+    "            if len(motion)>0:\n",
+    "                if motion.shape[1]==7: #incl. acc and rotational velocities\n",
+    "                    motion_df = pd.DataFrame(motion, columns=['acceleration_x', 'acceleration_y', 'acceleration_z',\n",
+    "                                                             'rotation_alpha', 'rotation_beta', 'rotation_gamma',\n",
+    "                                                              'timestamp'\n",
+    "                                                             ])\\\n",
+    "                                    .sort_values('timestamp', ascending=True)\\\n",
+    "                                    .drop('timestamp', axis=1)\n",
+    "                \n",
+    "                elif motion.shape[1]==4: #incl. acc only\n",
+    "                    motion_df = pd.DataFrame(motion, columns=['acceleration_x', 'acceleration_y', 'acceleration_z',\n",
+    "                                                              'timestamp'\n",
+    "                                                             ])\\\n",
+    "                                    .sort_values('timestamp', ascending=True)\\\n",
+    "                                    .drop('timestamp', axis=1)\n",
+    "\n",
+    "                else: #shouldn't enter\n",
+    "                    motion_df = pd.DataFrame()\n",
+    "            else: #no motion data recorded\n",
+    "                motion_df = pd.DataFrame()\n",
+    "\n",
+    "\n",
+    "            #process orientation data\n",
+    "            if len(orientation) > 0:\n",
+    "                orientation_df = pd.DataFrame(orientation, columns=['alpha', 'beta', 'gamma', 'timestamp'])\\\n",
+    "                                        .sort_values('timestamp', ascending=True)\\\n",
+    "                                        .drop('timestamp', axis=1)\n",
+    "            else:\n",
+    "                orientation_df = pd.DataFrame()\n",
+    "\n",
+    "            data.append((counter, gesture, motion_df, orientation_df))\n",
+    "\n",
+    "            counter += 1\n",
+    "    \n",
+    "    return data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Read raw dance and crosses data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = s3fs.S3FileSystem()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_to_dance_data = 'cchase-rh-demo-4/training-data'\n",
+    "path_to_cross_data = 'cchase-rh-demo-4/mock-server-data/motions/2019-02-26'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dance_raw   = get_raw_data(fs, path_to_dance_data, debug=False)\n",
+    "data_cross_raw = get_raw_data(fs, path_to_cross_data, debug=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counter = 0\n",
+    "data_dance_proc = process_dance_data(data_dance_raw)\n",
+    "data_cross_proc = process_crosses_data(data_cross_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = data_dance_proc + data_cross_proc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [d for d in data if d[2].shape[1]==6 and d[2].shape[0]>50] # <---- clean data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array(['draw-circle', 'draw-cross', 'draw-triangle', 'fever', 'floss',\n",
+       "        'roll', 'shake'], dtype='<U13'),\n",
+       " array([121, 185, 128, 122, 110, 137, 136]))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.unique([d[1] for d in data], return_counts=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def featurize(ts, bins, TAG):\n",
+    "    '''Take time-series and create features\n",
+    "    '''\n",
+    "    mean = np.mean(ts)\n",
+    "    median = np.median(ts)\n",
+    "    std = np.std(ts)\n",
+    "    length = len(ts)\n",
+    "    kurtosis = scipy.stats.kurtosis(ts)\n",
+    "    \n",
+    "    n,b = np.histogram(ts, bins=bins)\n",
+    "    n = np.array(n)/float(np.sum(n)) #normalize i.e. fraction of entries in each bin\n",
+    "    \n",
+    "    if median == 0: \n",
+    "        features = {f'{TAG}_mean_over_median': 0, #dimensionless            \n",
+    "                    f'{TAG}_std_over_median': 0, #dimensionless            \n",
+    "                    f'{TAG}_length': length,\n",
+    "                    f'{TAG}_kurtosis': kurtosis, #already dimensionless by definition\n",
+    "                   }\n",
+    "        \n",
+    "    else: \n",
+    "        features = {f'{TAG}_mean_over_median': mean/median, #dimensionless            \n",
+    "            f'{TAG}_std_over_median': std/median, #dimensionless            \n",
+    "            f'{TAG}_length': length,\n",
+    "            f'{TAG}_kurtosis': kurtosis, #already dimensionless by definition\n",
+    "           }\n",
+    "        \n",
+    "    for i, val in enumerate(n):\n",
+    "        features[f'{TAG}_binfrac_{i}'] = val\n",
+    "        \n",
+    "    \n",
+    "    return features\n",
+    "\n",
+    "def find_bins(ts_list, method='freedman'):\n",
+    "    ''' Find bin edges for histograms based on different methods\n",
+    "    '''\n",
+    "    \n",
+    "    ts_all = np.concatenate(ts_list)\n",
+    "    \n",
+    "    plt.clf()\n",
+    "    if method in ['freedman', 'scott', 'knuth', 'blocks']:\n",
+    "        n,b = np.histogram(ts_all, bins=method)\n",
+    "        plt.hist(ts_all, bins=b)\n",
+    "    else:\n",
+    "        n,b,p = plt.hist(ts_all)\n",
+    "    \n",
+    "    return ts_all, b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAD8CAYAAACLrvgBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAGHRJREFUeJzt3X+s3fV93/Hna/agSTaCgUvKbJidxclqUKcSL7irWmWhBUO6mGkgGW3DSpGsMei6aVFjlj+oQpBI140NLaGiwcNEEQ5jabEaM9cjZNEkfpmQAIZQ35gs3ECxExvGlgXq5L0/zuemp5dz7/36HPue6+T5kI7O9/v+fr7f8z7mi1/+/jjnpKqQJKmLvzLuBiRJJw5DQ5LUmaEhSerM0JAkdWZoSJI6MzQkSZ0ZGpKkzgwNSVJnhoYkqbOl427gWDvjjDNq5cqV425Dkk4ojz/++HeramK+cT9xobFy5Ur27Nkz7jYk6YSS5H91GefpKUlSZ4aGJKkzQ0OS1JmhIUnqzNCQJHVmaEiSOps3NJJsTXIgydMz6r+Z5Lkke5P8bl/9+iSTbdnFffX1rTaZZEtffVWSR5LsS/L5JCe1+sltfrItX3ks3rAkaXhdjjTuBNb3F5L8fWAD8PNVdS7we62+BtgInNvW+XSSJUmWAJ8CLgHWAFe2sQCfBG6pqtXAYeDqVr8aOFxV7wJuaeMkSWM0b2hU1VeAQzPK1wA3V9XrbcyBVt8AbK+q16vqeWASeF97TFbV/qp6A9gObEgS4APAvW39bcBlfdva1qbvBS5s4yVJYzLsJ8LfDfxykpuAHwAfqarHgOXAw33jploN4IUZ9QuA04FXqurIgPHLp9epqiNJXm3jvztkz9JYrdzyxbG99rdu/uDYXls/WYYNjaXAMmAd8HeBe5K8Exh0JFAMPqKpOcYzz7K/JMlmYDPAOeecM2fjkqThDXv31BTwhep5FPgRcEarn903bgXw4hz17wKnJlk6o07/Om3523nzaTIAqur2qlpbVWsnJub9vi1J0pCGDY0/onctgiTvBk6iFwA7gI3tzqdVwGrgUeAxYHW7U+okehfLd1RVAQ8Cl7ftbgLua9M72jxt+ZfaeEnSmMx7eirJ3cD7gTOSTAE3AFuBre023DeATe0v9L1J7gGeAY4A11bVD9t2rgN2AUuArVW1t73ER4HtST4BPAHc0ep3AJ9NMknvCGPjMXi/kqQRzBsaVXXlLIv+ySzjbwJuGlDfCewcUN9P7+6qmfUfAFfM158kaeH4iXBJUmeGhiSpM0NDktSZoSFJ6szQkCR1ZmhIkjozNCRJnRkakqTODA1JUmeGhiSpM0NDktSZoSFJ6szQkCR1ZmhIkjozNCRJnRkakqTODA1JUmfzhkaSrUkOtJ92nbnsI0kqyRltPkluTTKZ5Mkk5/eN3ZRkX3ts6qu/N8lTbZ1bk6TVT0uyu43fnWTZsXnLkqRhdTnSuBNYP7OY5Gzg14Bv95UvAVa3x2bgtjb2NHq/LX4BvZ92vaEvBG5rY6fXm36tLcADVbUaeKDNS5LGaN7QqKqvAIcGLLoF+G2g+mobgLuq52Hg1CRnARcDu6vqUFUdBnYD69uyU6rqoaoq4C7gsr5tbWvT2/rqkqQxGeqaRpIPAd+pqq/PWLQceKFvfqrV5qpPDagDvKOqXgJoz2cO06sk6dhZerQrJHkr8DHgokGLB9RqiPrR9rSZ3ikuzjnnnKNdXZLU0TBHGn8LWAV8Pcm3gBXAV5P8LL0jhbP7xq4AXpynvmJAHeDldvqK9nxgtoaq6vaqWltVaycmJoZ4S5KkLo46NKrqqao6s6pWVtVKen/xn19VfwbsAK5qd1GtA15tp5Z2ARclWdYugF8E7GrLXkuyrt01dRVwX3upHcD0XVab+uqSpDHpcsvt3cBDwHuSTCW5eo7hO4H9wCTwB8A/B6iqQ8CNwGPt8fFWA7gG+Exb55vA/a1+M/BrSfbRu0vr5qN7a5KkY23eaxpVdeU8y1f2TRdw7SzjtgJbB9T3AOcNqH8PuHC+/iRJC8dPhEuSOjM0JEmdGRqSpM4MDUlSZ4aGJKkzQ0OS1JmhIUnqzNCQJHVmaEiSOjM0JEmdGRqSpM4MDUlSZ4aGJKkzQ0OS1JmhIUnqzNCQJHVmaEiSOuvyc69bkxxI8nRf7d8m+UaSJ5P8YZJT+5Zdn2QyyXNJLu6rr2+1ySRb+uqrkjySZF+Szyc5qdVPbvOTbfnKY/WmJUnD6XKkcSewfkZtN3BeVf088KfA9QBJ1gAbgXPbOp9OsiTJEuBTwCXAGuDKNhbgk8AtVbUaOAxM/wb51cDhqnoXcEsbJ0kao3lDo6q+AhyaUfuTqjrSZh8GVrTpDcD2qnq9qp4HJoH3tcdkVe2vqjeA7cCGJAE+ANzb1t8GXNa3rW1t+l7gwjZekjQmx+Kaxm8A97fp5cALfcumWm22+unAK30BNF3/S9tqy19t498kyeYke5LsOXjw4MhvSJI02EihkeRjwBHgc9OlAcNqiPpc23pzser2qlpbVWsnJibmblqSNLSlw66YZBPw68CFVTX9l/kUcHbfsBXAi216UP27wKlJlrajif7x09uaSrIUeDszTpNJkhbWUEcaSdYDHwU+VFXf71u0A9jY7nxaBawGHgUeA1a3O6VOonexfEcLmweBy9v6m4D7+ra1qU1fDnypL5wkSWMw75FGkruB9wNnJJkCbqB3t9TJwO52bfrhqvpnVbU3yT3AM/ROW11bVT9s27kO2AUsAbZW1d72Eh8Ftif5BPAEcEer3wF8NskkvSOMjcfg/UqSRjBvaFTVlQPKdwyoTY+/CbhpQH0nsHNAfT+9u6tm1n8AXDFff5KkheMnwiVJnRkakqTODA1JUmeGhiSpM0NDktSZoSFJ6szQkCR1ZmhIkjozNCRJnRkakqTODA1JUmeGhiSpM0NDktSZoSFJ6mzoX+6TTlQrt3xx3C1IJyyPNCRJnc0bGkm2JjmQ5Om+2mlJdifZ156XtXqS3JpkMsmTSc7vW2dTG7+v/b74dP29SZ5q69ya9lOAs72GJGl8uhxp3Amsn1HbAjxQVauBB9o8wCX0fhd8NbAZuA16AUDvZ2IvoPcrfTf0hcBtbez0euvneQ1J0pjMGxpV9RV6v9HdbwOwrU1vAy7rq99VPQ8DpyY5C7gY2F1Vh6rqMLAbWN+WnVJVD1VVAXfN2Nag15Akjcmw1zTeUVUvAbTnM1t9OfBC37ipVpurPjWgPtdrSJLG5FhfCM+AWg1RP7oXTTYn2ZNkz8GDB492dUlSR8OGxsvt1BLt+UCrTwFn941bAbw4T33FgPpcr/EmVXV7Va2tqrUTExNDviVJ0nyGDY0dwPQdUJuA+/rqV7W7qNYBr7ZTS7uAi5IsaxfALwJ2tWWvJVnX7pq6asa2Br2GJGlM5v1wX5K7gfcDZySZoncX1M3APUmuBr4NXNGG7wQuBSaB7wMfBqiqQ0luBB5r4z5eVdMX16+hd4fWW4D724M5XkOSNCbzhkZVXTnLogsHjC3g2lm2sxXYOqC+BzhvQP17g15DkjQ+fiJcktSZoSFJ6szQkCR1ZmhIkjozNCRJnRkakqTODA1JUmeGhiSpM0NDktSZoSFJ6szQkCR1ZmhIkjozNCRJnRkakqTODA1JUmeGhiSpM0NDktTZSKGR5F8l2Zvk6SR3J/mZJKuSPJJkX5LPJzmpjT25zU+25Sv7tnN9qz+X5OK++vpWm0yyZZReJUmjGzo0kiwH/gWwtqrOA5YAG4FPArdU1WrgMHB1W+Vq4HBVvQu4pY0jyZq23rnAeuDTSZYkWQJ8CrgEWANc2cZKksZk1NNTS4G3JFkKvBV4CfgAcG9bvg24rE1vaPO05RcmSatvr6rXq+p5YBJ4X3tMVtX+qnoD2N7GSpLGZOjQqKrvAL8HfJteWLwKPA68UlVH2rApYHmbXg680NY90saf3l+fsc5sdUnSmIxyemoZvX/5rwL+BvA2eqeSZqrpVWZZdrT1Qb1sTrInyZ6DBw/O17okaUijnJ76VeD5qjpYVX8OfAH4e8Cp7XQVwArgxTY9BZwN0Ja/HTjUX5+xzmz1N6mq26tqbVWtnZiYGOEtSZLmMkpofBtYl+St7drEhcAzwIPA5W3MJuC+Nr2jzdOWf6mqqtU3trurVgGrgUeBx4DV7W6sk+hdLN8xQr+SpBEtnX/IYFX1SJJ7ga8CR4AngNuBLwLbk3yi1e5oq9wBfDbJJL0jjI1tO3uT3EMvcI4A11bVDwGSXAfsondn1taq2jtsv5Kk0Q0dGgBVdQNww4zyfnp3Ps0c+wPgilm2cxNw04D6TmDnKD1Kko4dPxEuSerM0JAkdWZoSJI6MzQkSZ0ZGpKkzgwNSVJnhoYkqTNDQ5LUmaEhSerM0JAkdWZoSJI6MzQkSZ0ZGpKkzgwNSVJnhoYkqTNDQ5LUmaEhSepspNBIcmqSe5N8I8mzSX4xyWlJdifZ156XtbFJcmuSySRPJjm/bzub2vh9STb11d+b5Km2zq3tt8glSWMy6pHGfwT+W1X9beDvAM8CW4AHqmo18ECbB7gEWN0em4HbAJKcRu8nYy+g9zOxN0wHTRuzuW+99SP2K0kawdChkeQU4FeAOwCq6o2qegXYAGxrw7YBl7XpDcBd1fMwcGqSs4CLgd1VdaiqDgO7gfVt2SlV9VBVFXBX37YkSWMwypHGO4GDwH9O8kSSzyR5G/COqnoJoD2f2cYvB17oW3+q1eaqTw2oS5LGZJTQWAqcD9xWVb8A/F/+4lTUIIOuR9QQ9TdvONmcZE+SPQcPHpy7a0nS0EYJjSlgqqoeafP30guRl9upJdrzgb7xZ/etvwJ4cZ76igH1N6mq26tqbVWtnZiYGOEtSZLmMnRoVNWfAS8keU8rXQg8A+wApu+A2gTc16Z3AFe1u6jWAa+201e7gIuSLGsXwC8CdrVlryVZ1+6auqpvW5KkMVg64vq/CXwuyUnAfuDD9ILoniRXA98GrmhjdwKXApPA99tYqupQkhuBx9q4j1fVoTZ9DXAn8Bbg/vaQJI3JSKFRVV8D1g5YdOGAsQVcO8t2tgJbB9T3AOeN0qMk6djxE+GSpM4MDUlSZ4aGJKkzQ0OS1JmhIUnqzNCQJHVmaEiSOjM0JEmdGRqSpM4MDUlSZ4aGJKkzQ0OS1JmhIUnqzNCQJHVmaEiSOjM0JEmdGRqSpM5GDo0kS5I8keSP2/yqJI8k2Zfk8+2nYElycpufbMtX9m3j+lZ/LsnFffX1rTaZZMuovUqSRnMsjjR+C3i2b/6TwC1VtRo4DFzd6lcDh6vqXcAtbRxJ1gAbgXOB9cCnWxAtAT4FXAKsAa5sYyVJYzJSaCRZAXwQ+EybD/AB4N42ZBtwWZve0OZpyy9s4zcA26vq9ap6HpgE3tcek1W1v6reALa3sZKkMRn1SOM/AL8N/KjNnw68UlVH2vwUsLxNLwdeAGjLX23jf1yfsc5s9TdJsjnJniR7Dh48OOJbkiTNZujQSPLrwIGqery/PGBozbPsaOtvLlbdXlVrq2rtxMTEHF1LkkaxdIR1fwn4UJJLgZ8BTqF35HFqkqXtaGIF8GIbPwWcDUwlWQq8HTjUV5/Wv85sdUnSGAx9pFFV11fViqpaSe9C9peq6h8DDwKXt2GbgPva9I42T1v+paqqVt/Y7q5aBawGHgUeA1a3u7FOaq+xY9h+JUmjG+VIYzYfBbYn+QTwBHBHq98BfDbJJL0jjI0AVbU3yT3AM8AR4Nqq+iFAkuuAXcASYGtV7T0O/UqSOjomoVFVXwa+3Kb307vzaeaYHwBXzLL+TcBNA+o7gZ3HokdJ0uj8RLgkqTNDQ5LUmaEhSerM0JAkdWZoSJI6MzQkSZ0ZGpKkzgwNSVJnhoYkqTNDQ5LUmaEhSerM0JAkdWZoSJI6MzQkSZ0ZGpKkzgwNSVJnQ4dGkrOTPJjk2SR7k/xWq5+WZHeSfe15Wasnya1JJpM8meT8vm1tauP3JdnUV39vkqfaOrcmyShvVpI0mlGONI4A/7qqfg5YB1ybZA2wBXigqlYDD7R5gEvo/f73amAzcBv0Qga4AbiA3i/+3TAdNG3M5r711o/QryRpREOHRlW9VFVfbdOvAc8Cy4ENwLY2bBtwWZveANxVPQ8DpyY5C7gY2F1Vh6rqMLAbWN+WnVJVD1VVAXf1bUuSNAbH5JpGkpXALwCPAO+oqpegFyzAmW3YcuCFvtWmWm2u+tSAuiRpTEYOjSR/DfivwL+sqv8919ABtRqiPqiHzUn2JNlz8ODB+VqWJA1ppNBI8lfpBcbnquoLrfxyO7VEez7Q6lPA2X2rrwBenKe+YkD9Tarq9qpaW1VrJyYmRnlLkqQ5jHL3VIA7gGer6t/3LdoBTN8BtQm4r69+VbuLah3wajt9tQu4KMmydgH8ImBXW/ZaknXtta7q25YkaQyWjrDuLwH/FHgqydda7d8ANwP3JLka+DZwRVu2E7gUmAS+D3wYoKoOJbkReKyN+3hVHWrT1wB3Am8B7m8PSdKYDB0aVfU/GXzdAeDCAeMLuHaWbW0Ftg6o7wHOG7ZHSdKx5SfCJUmdGRqSpM4MDUlSZ4aGJKmzUe6eknSCWLnli2N53W/d/MGxvK6OH480JEmdGRqSpM4MDUlSZ4aGJKkzQ0OS1JmhIUnqzFtuNRbjugVU0mg80pAkdWZoSJI6MzQkSZ0ZGpKkzgwNSVJniz40kqxP8lySySRbxt2PJP00W9ShkWQJ8CngEmANcGWSNePtSpJ+ei32z2m8D5isqv0ASbYDG4BnxtqVpE7G+Xkcv5b9+FjsobEceKFvfgq4YEy9/ETyQ3aSjsZiD40MqNWbBiWbgc1t9v8kee64djW8M4DvjruJo3Ai9Wuvx8+J1O+Pe80nx9zJ/Bbbn+vf7DJosYfGFHB23/wK4MWZg6rqduD2hWpqWEn2VNXacffR1YnUr70ePydSv/Z6/C3qC+HAY8DqJKuSnARsBHaMuSdJ+qm1qI80qupIkuuAXcASYGtV7R1zW5L0U2tRhwZAVe0Edo67j2Nk0Z9Cm+FE6tdej58TqV97Pc5S9abrypIkDbTYr2lIkhYRQ+MYSnJFkr1JfpRkbV99ZZL/l+Rr7fH7fcvem+Sp9jUptyZJq5+WZHeSfe152UL02pZd3/p5LsnFffWBX+nSblR4pPX6+XbTwnGT5HeSfKfvz/PSYXtfaIulj35JvtX2wa8l2dNqA/e/9Nza+n8yyfkL0N/WJAeSPN1XO+r+kmxq4/cl2bSAvZ6w++tAVeXjGD2AnwPeA3wZWNtXXwk8Pcs6jwK/SO8zKfcDl7T67wJb2vQW4JML1Osa4OvAycAq4Jv0bkJY0qbfCZzUxqxp69wDbGzTvw9cc5z/nH8H+MiA+lH3vsD7x6LoY0Bf3wLOmFEbuP8Bl7b9NMA64JEF6O9XgPP7/x862v6A04D97XlZm162QL2ekPvrbA+PNI6hqnq2qjp/sDDJWcApVfVQ9faiu4DL2uINwLY2va2vfrx73QBsr6rXq+p5YJLe17n8+CtdquoNYDuwoR0ZfQC493j1ehSOqvcx9LdY+uhitv1vA3BX9TwMnNr24+Omqr4CHBqxv4uB3VV1qKoOA7uB9QvU62wW+/46kKGxcFYleSLJ/0jyy622nN4HGKdNtRrAO6rqJYD2fOYC9Tnoq1uWz1E/HXilqo7MqB9v17XTD1v7Tt0dbe8LbbH0MVMBf5Lk8fS+XQFm3/8Wy3s42v7G3feJuL8OtOhvuV1skvx34GcHLPpYVd03y2ovAedU1feSvBf4oyTn0vFrUoY1ZK+z9TToHxg1x/iRzNU7cBtwY3udG4F/B/zGHL3M1vtCO67/vUfwS1X1YpIzgd1JvjHH2MX6HqbN1t84+z5R99eBDI2jVFW/OsQ6rwOvt+nHk3wTeDe9f0Gs6Bva/zUpLyc5q6peaofXBxaiV+b+6pZB9e/SOwWwtB1tDPyql6PVtfckfwD8cZs92t4XWqevxVloVfViez6Q5A/pnR6Zbf9bLO/haPubAt4/o/7lBeiTqnp5evoE218H8vTUAkgykd5vg5DkncBqYH87rH4tybp2beAqYPoIYAcwfYfHpr768bYD2Jjk5CSrWq+PMstXurRrMQ8Cly9UrzPOof9DYPpOlaPq/Xj2OIvF0sePJXlbkr8+PQ1cRO/Pc7b9bwdwVbtLaR3w6vRpogV2tP3tAi5KsqydHrqo1Y67E3h/HWzcV+J/kh70dogpekcVLwO7Wv0fAXvp3QXxVeAf9K2zlt5O9E3gP/EXH7g8HXgA2NeeT1uIXtuyj7V+nqPdzdXqlwJ/2pZ9rK/+Tno7+yTwX4CTj/Of82eBp4An6f3PdNawvY9hH1kUfcz4b/f19tg73dNs+x+9Uyqfav0/Rd+dd8exx7vpneL987bPXj1Mf/ROCU22x4cXsNcTdn8d9PAT4ZKkzjw9JUnqzNCQJHVmaEiSOjM0JEmdGRqSpM4MDUlSZ4aGJKkzQ0OS1Nn/B58SMTuAkl7QAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cols = ['acceleration_x', 'acceleration_y', 'acceleration_z',\n",
+    "       'rotation_alpha', 'rotation_beta', 'rotation_gamma']\n",
+    "method = 'plt'\n",
+    "\n",
+    "col_bins = {}\n",
+    "\n",
+    "for col in cols:\n",
+    "    ts_all, b = find_bins([d[2][col] for d in data], method=method)\n",
+    "    col_bins[col] = b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols = ['acceleration_x', 'acceleration_y', 'acceleration_z',\n",
+    "        'rotation_alpha', 'rotation_beta', 'rotation_gamma']\n",
+    "\n",
+    "df_list = []\n",
+    "for col in cols:\n",
+    "    index_list, feature_list, label_list = [], [], []\n",
+    "    for d in data:\n",
+    "        features = featurize(d[2][col], bins=col_bins[col], TAG=col.upper())\n",
+    "        \n",
+    "        feature_list.append(features)\n",
+    "        index_list.append(d[0])\n",
+    "        label_list.append(d[1])\n",
+    "    \n",
+    "    feature_col_df = pd.DataFrame(feature_list)\n",
+    "    \n",
+    "    df_list.append(feature_col_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.concat(df_list, axis=1)\n",
+    "df['index'] = index_list\n",
+    "df['label'] = label_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ACCELERATION_X_binfrac_0                     0\n",
+       "ACCELERATION_X_binfrac_1                     0\n",
+       "ACCELERATION_X_binfrac_2                     0\n",
+       "ACCELERATION_X_binfrac_3                     0\n",
+       "ACCELERATION_X_binfrac_4               0.22884\n",
+       "ACCELERATION_X_binfrac_5              0.761755\n",
+       "ACCELERATION_X_binfrac_6            0.00940439\n",
+       "ACCELERATION_X_binfrac_7                     0\n",
+       "ACCELERATION_X_binfrac_8                     0\n",
+       "ACCELERATION_X_binfrac_9                     0\n",
+       "ACCELERATION_X_kurtosis               0.184926\n",
+       "ACCELERATION_X_length                      319\n",
+       "ACCELERATION_X_mean_over_median        3.48315\n",
+       "ACCELERATION_X_std_over_median        -27.2695\n",
+       "ACCELERATION_Y_binfrac_0                     0\n",
+       "ACCELERATION_Y_binfrac_1                     0\n",
+       "ACCELERATION_Y_binfrac_2                     0\n",
+       "ACCELERATION_Y_binfrac_3                     0\n",
+       "ACCELERATION_Y_binfrac_4              0.990596\n",
+       "ACCELERATION_Y_binfrac_5            0.00940439\n",
+       "ACCELERATION_Y_binfrac_6                     0\n",
+       "ACCELERATION_Y_binfrac_7                     0\n",
+       "ACCELERATION_Y_binfrac_8                     0\n",
+       "ACCELERATION_Y_binfrac_9                     0\n",
+       "ACCELERATION_Y_kurtosis               -0.32075\n",
+       "ACCELERATION_Y_length                      319\n",
+       "ACCELERATION_Y_mean_over_median        3.45779\n",
+       "ACCELERATION_Y_std_over_median         17.0681\n",
+       "ACCELERATION_Z_binfrac_0                     0\n",
+       "ACCELERATION_Z_binfrac_1                     0\n",
+       "                                      ...     \n",
+       "ROTATION_BETA_binfrac_0                      0\n",
+       "ROTATION_BETA_binfrac_1                      0\n",
+       "ROTATION_BETA_binfrac_2                      0\n",
+       "ROTATION_BETA_binfrac_3                      0\n",
+       "ROTATION_BETA_binfrac_4               0.253918\n",
+       "ROTATION_BETA_binfrac_5               0.746082\n",
+       "ROTATION_BETA_binfrac_6                      0\n",
+       "ROTATION_BETA_binfrac_7                      0\n",
+       "ROTATION_BETA_binfrac_8                      0\n",
+       "ROTATION_BETA_binfrac_9                      0\n",
+       "ROTATION_BETA_kurtosis               -0.167105\n",
+       "ROTATION_BETA_length                       319\n",
+       "ROTATION_BETA_mean_over_median        0.589452\n",
+       "ROTATION_BETA_std_over_median          8.80727\n",
+       "ROTATION_GAMMA_binfrac_0                     0\n",
+       "ROTATION_GAMMA_binfrac_1                     0\n",
+       "ROTATION_GAMMA_binfrac_2                     0\n",
+       "ROTATION_GAMMA_binfrac_3                     0\n",
+       "ROTATION_GAMMA_binfrac_4              0.316614\n",
+       "ROTATION_GAMMA_binfrac_5              0.683386\n",
+       "ROTATION_GAMMA_binfrac_6                     0\n",
+       "ROTATION_GAMMA_binfrac_7                     0\n",
+       "ROTATION_GAMMA_binfrac_8                     0\n",
+       "ROTATION_GAMMA_binfrac_9                     0\n",
+       "ROTATION_GAMMA_kurtosis               0.248245\n",
+       "ROTATION_GAMMA_length                      319\n",
+       "ROTATION_GAMMA_mean_over_median        10.4361\n",
+       "ROTATION_GAMMA_std_over_median        -42.2039\n",
+       "index                                       20\n",
+       "label                              draw-circle\n",
+       "Name: 0, Length: 86, dtype: object"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "draw-cross     185\n",
+       "roll           137\n",
+       "shake          136\n",
+       "fever          122\n",
+       "draw-circle    121\n",
+       "floss          110\n",
+       "Name: label, dtype: int64"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = df[~df['label'].isin(['draw-triangle'])]\n",
+    "df['label'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train size = (567, 86)\n",
+      "test size = (244, 86)\n",
+      "draw-cross     128\n",
+      "shake          105\n",
+      "fever           90\n",
+      "draw-circle     84\n",
+      "roll            83\n",
+      "floss           77\n",
+      "Name: label, dtype: int64\n",
+      "draw-cross     57\n",
+      "roll           54\n",
+      "draw-circle    37\n",
+      "floss          33\n",
+      "fever          32\n",
+      "shake          31\n",
+      "Name: label, dtype: int64\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mcliffor/anaconda3/envs/tf/lib/python3.6/site-packages/sklearn/model_selection/_split.py:2179: FutureWarning: From version 0.21, test_size will always complement train_size unless both are specified.\n",
+      "  FutureWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "np.random.seed(0)\n",
+    "\n",
+    "train_df, test_df = train_test_split(df, train_size=0.70)\n",
+    "\n",
+    "print(f'train size = {train_df.shape}')\n",
+    "print(f'test size = {test_df.shape}')\n",
+    "\n",
+    "print(train_df['label'].value_counts())\n",
+    "print(test_df['label'].value_counts())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_confusion_matrix(train_labels, train_pred):\n",
+    "    fig = plt.figure(figsize=(8,8))\n",
+    "    ax = plt.subplot()\n",
+    "\n",
+    "    labels = np.sort(list(train_labels.value_counts().index))\n",
+    "\n",
+    "    confusion = confusion_matrix(train_labels, train_pred, labels=labels)\n",
+    "    ax.matshow(confusion)\n",
+    "\n",
+    "    ax.set_xticks(range(len(labels)))\n",
+    "    ax.set_yticks(range(len(labels)))\n",
+    "\n",
+    "    ax.set_xticklabels(labels, rotation=90);\n",
+    "    ax.set_yticklabels(labels);\n",
+    "\n",
+    "    for i in range(len(labels)):\n",
+    "        for j in range(len(labels)):        \n",
+    "            ax.text(j, i, confusion[i,j], va='center', ha='center')\n",
+    "\n",
+    "    plt.xlabel('predicted')    \n",
+    "    plt.ylabel('true')\n",
+    "    \n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_label = np.array(train_df['label'])\n",
+    "test_label = np.array(test_df['label'])\n",
+    "\n",
+    "label_encoder = LabelEncoder()\n",
+    "one_hot_encoder = OneHotEncoder(sparse=False,categories='auto')\n",
+    "\n",
+    "train_integer = label_encoder.fit_transform(train_label)\n",
+    "train_onehot = one_hot_encoder.fit_transform(train_integer.reshape(len(train_integer), 1))\n",
+    "\n",
+    "test_integer = label_encoder.transform(test_label)\n",
+    "test_onehot = one_hot_encoder.transform(test_integer.reshape(len(test_integer), 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_1 = keras.Sequential([\n",
+    "    keras.layers.Dense(25, activation=tf.nn.relu, input_shape=(85,)),\n",
+    "    keras.layers.Dense(6, activation=tf.nn.log_softmax)\n",
+    "]) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adm = tf.train.AdamOptimizer(learning_rate=1e-3)\n",
+    "model_1.compile(optimizer=adm, \n",
+    "              loss=tf.losses.softmax_cross_entropy,\n",
+    "              metrics=['accuracy'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = model_1.fit( train_df.drop('label', axis=1), train_onehot, epochs=5000, verbose=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "244/244 [==============================] - 0s 129us/step\n",
+      "Test accuracy: 0.9139344252523829\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_loss, test_acc = model_1.evaluate(test_df.drop('label', axis=1), test_onehot)\n",
+    "\n",
+    "print('Test accuracy:', test_acc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0, 0.5, 'predicted')"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAFqCAYAAAA6M7CZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xl8nHW9/v/XNUmapWm6kLa0pTu0aAELlFVA8XAEZREQEReO4oLLF7fj8vUc/Xk46lGPy3HBI8rXoyjgAipaN0BZC1LWFgpHQGVvWRpS6JakSeb9+2PuYKBZJm2Sez7hej4e88jMPXdmrtydXnPPZ+5FEYGZmaWjkHcAMzMbGhe3mVliXNxmZolxcZuZJcbFbWaWGBe3mVliXNxmZolxcZuZJcbFbWaWGBe3veBJmi7pfyT9Prv9YklvzzuXWX9c3BVM0hclNUmqkXSlpBZJb8471xh0PnA5MDO7fR/wwdzSmA3CxV3ZXhkRG4HjgEeBRcBH8400JjVHxMVAESAiuoDufCOZ9c/FXdlqsp+vBn4cEa15hhnDtkjaBQgASQcDz+Qbyax/1XkHsAH9WtI9QBvwXklTgfacM41F/wwsBxZKugGYCpySbySz/smHda1skiYDGyOiW1ID0BQRj+eda6yRVA0sBgTcGxGdOUcy65fXuCuYpNcBl2Wl/UlgP+CzgIt7GEg6uZ+7FkkiIn4xqoHMyuQ17gom6c6I2EfSYcDngS8D/xoRB+UcbUyQ9P0B7o6IeNuohTEbAhd3BZO0KiL2lfR5YE1E/KhnWt7ZzCw/3qqksq2V9B3gVOB3kmrxv9mwk/Q5SZN63Z4s6bN5ZjIbiNe4K1j2ZeQxlNa2/yJpBrB3RFyRc7Qxpa9PMZJuj4j98spkNhCvvVWwiNgK/A04WtJZwDSX9oioyj7NACCpHqgdYH6zXLm4K5ikDwAXAdOyy4WS3pdvqjHpQuBKSW+X9DbgD8APcs5k1i8PlVQwSXcCh0TEluz2eODGiNgn32Rjj6RjgKMobcd9RURcnnMks355O+7KJp57zIzubJoNE0lVwOURcRRwWd55zMrh4q5s3wduknRpdvtE4H9yzDPmZDs3bZU0MSJ8fBJLgodKKpyk/YDDKK1pXxcRq3KONOZIuhg4mNLY9pae6RHx/txCmQ3AxV2hJBWAOyNir7yzjHWS3tLX9IjwF5RWkTxUUqEioijpDklzIuLhvPOMZS5oS42Lu7LNAO6WdDPP/Qh/Qn6Rxg5JF0fEqZLWkB2LuzdvvWOVykMlFUzSy/qaHhHXjnaWsUjSjIh4TNLcvu6PiIdGO5NZObzGXdkeBh6LiHZ4do++6flGGjsi4rHsagEvZ0uI95ysbJeQnQcx051Ns+Hl5WxJcXFXtuqI2NZzI7s+Lsc8Y5WXsyXFxV3Z1kt69otISa8BWnLMM1Z5OVtS/OVkBZO0kNJBpmZS2gHnEeD0iPhbrsHGGC9nK4ek8T3HDcqbizsBkhop/VttyjvLWOblbH2RdCjwXaAxIuZIegnwroh4b16ZPFSSgIjYDPw47xxjnZez9eOrwNHAUwARcQdwRJ6BXNzpmJV3gBcIL2fbTkQ88rxJ3X3OOEpc3OnwwaVGh5fzCJFUJemPeefYAY9kwyUhaZykjwB/zjOQi7uCSXpFdt5JIuJteecZq7ycR0dEdANbJU3MO8sQvRv4P5Q+jT0KLM1u58ZfTlYwST+kdLjRp4AV2eX6iNiQa7Axxst59KR4CF1JUyKi9XnT5kfEA7llcnFXPkkzgVOAjwAzI8KHKhgBKS3nbBPGRyOiQ9LLgX2AH0bE0/kmG1iKh9CVdAPwqojYmN1+EXBJnodcdnFXMElvBg4H9qa0Q8j1wIqIuDHXYGNMistZ0mpgGTAPuBxYDiyOiFfnmasc2bFg5kTEvXlnKYekY4GPAccCi4EfAm+KiNW5ZXJxVy5JLcDfgG8DV0fEg/kmGptSXM6Sbo+I/SR9FGiPiHMkrYqIffPONhBJxwNfBsZFxHxJS4FPV/qhiiWdSKm8JwAnR8Rf8sxTsR8FDSKiWdISStuM/oekPYB7I+L0nKONKYku505JbwDeAhyfTavJMU+5zgYOBK4BiIjVkubnGag/ks7hucdpbwLuB94nKddxeRd3BZPUBMwB5lL6SDyR5x7FzoZBosv5DEpbO/xHRDyQld+FOWcqR1dEPCOp97RK/dh/6/Nu35ZLij54qKSCSbqT0njr9ZROFPxozpHGpNSXs6TJwOyIuDPvLIOR9D/AlcDHgdcC7wdqIuLduQZLjIvbLEGSrgFOoPSpeTWwHrg2Iv45z1yDybaX/wTwymzS5cBne05iUYmyobPPAy8G6nqmR8SC3DK5uCuXpKmUvhBZwnNfMK/ILdQYlOJy7vkiUtI7KK1t/5ukOyv9PJmS9o2IpPZOlXQ98G+UjllyPKVhKkXEv+WVyXtOVraLgHuA+cC/Aw8Ct+QZqD+SNkna2Mdlk6SNeecbRDLLuZdqSTOAU4Hf5B1mCP5L0j2SPpN9IZyC+oi4klJZPxQRZwO5vqm7uCvbLhHxP0BnRFyb7Y59cN6h+hIREyKiqY/LhIhoyjvfIJJZzr18mtIww98i4hZJC4BcN1ErR0QcCbyc0tDOeZLWSPpkvqkG1S6pAPxF0lmSTgKm5RnIQyUVTNLKiDhY0uXAN4B1wM8iYmHO0bYjacpA9z9/l+FKktJyHksk7U1piOr1EVGxp4qTdAClg0pNAj5DaaujL0bEytwyubgrl6TjKB03YzZwDqXtSP89IpbnGqwPkh6gtFmX+rg78vwiZzApLeceknajlPWllJb79cAHKn2LmGx38dcDr6O0l+pPgJ9HxJO5BkuMi7tCSaoC3h8RX807y1iW6nKW9AfgR8AF2aQ3U9oN+x/zSzU4SSspnazikohYl3eeckhaBHyU0nb+z+77kueX1y7uCibp6mxMMCnZiXd7zhByTURU9JdnKS5nSasjYulg0ypRgscquYPS4RBuo9cJFCIitx1yvOdkZfuTpG8CP+W5h8C8Pb9IA5P0BeAASltqAHxA0ksj4l9yjDWY5JYz0JIdHKvnVGtvIDu1ViXrfawSIJVjlXRFxLl5h+jNa9wVTNLV2dWefyRRGi+u5O2L7wSWRkQxu10FrKrk7YsTXc5zgG8Ch1DK/SdKY9wP5RpsEJJuo7Qp3TU9B8Sq1O3Pe33h/n7gSeBSoKPn/jy/cPcadwWS1LP322/Y/gu/FN5pJwE9L+qKPdtJyss5Ih6mtOdkavo6Vkmluo3nvi4+ynNfF7l94e7irkwTsp+LKQ07/IrSi+d44Lq8Qg1Gpf+NXwZWZWuxojTWXanDJMktZ0nfGOj+Sj6TTOYuSW8EqrJdyd9P6dNCxYmI+QCSTgUui4iNkv4/YD9KmwXmxkMlFUzSFcBrI2JTdnsCpW/jj8k3Wf+yj8LHUSpCATdFxOP5phpYSstZ0qOUjvUxGdju1GqVeiYZSRdExOmS/hUYT+lYJaK0E9FnKvxYJXdGxD6SDgM+B3wF+NeIOCivTF7jrmxzgG29bm+jdNjRSrYS2K2St4HuQ0rLeSOlY1kvB1LaEmZ/SXMpbcN9JKXy69EAVGxx8/ctSY4Fvh0Rv5J0do55XNwV7gLgZkmXUhpbOwmoyDWqXo4E3iXpIUpbaPR80VdxXz71ktJy/jZwGaXx1d7Hixal7JW6o1OquQHWSvoOcBTwn5JqyflwIR4qqXCS9qN0PkQoHSu6oo+slq1VbSeBrR1SW87nRsR78s4xVCnmzg5FewywJiL+kh3ca++IuCK3TC5uM7O0+OiAZmaJcXEnQtKZeWfYESnmdubRkWJmqIzcLu505P5i2UEp5nbm0ZFiZqiA3C5uM7PE+MvJYdY8pSrmzB7+rSxbnuqmeZeqYX9cgL/eOX5EHhegkw5qqB2ZBx+h3aY7o50a1Q0+YwVx5u2pamTWS7cV2xlXGP7cbd2b2FZsL+tF7e24h9mc2dVc9/td844xJCftdmDeEXaIair2pClWAQoTJww+UwW5ccPPy57XQyVmZolxcZuZJcbFbWaWGBe3mVliXNxmZolxcZuZJcbFbWaWGBe3mVliXNxmZolxcZuZJcbFbWaWGBe3mVliXNxmZolxcZuZJcbFbWaWGBe3mVlifCKFCrXkoLU0NhaoKkB1tbju97ty6a+38rn/eoZ7/9LJNb+dzn4vGaEzywyDlnic+1hNEMxiPvO0Z96RBnV310rWF9cyTnUcWnNs3nHK4syjozu6uPnp5RSjmyDYtXY+u48/ILc8o1rcks4GNkfEl0fzeVP120um0Tzl76cre9GeNVz0/5r5wMdbc0w1uIjgXlaxL4dTRwM3cyXNMZNGNeUdbUAzCwuYXVjEXd035h2lbM48OgpUccCk46lWDcXo5uanl9M8bg6Taqbnkif3NW5J1RHRNUrPVRUR3aPxXCNhzz1q8o5QlmdopZ5GGtQIwPSYzXrW0UhlF/fkwjTaYnPeMYbEmUeHJKop/f8LihQp5ppnxMe4JX1C0r2S/ggszqZdI+lzkq4FPiDpeEk3SVol6Y+SpmfzrZE0SSVPSfqnbPoFko7q47l2z37/Dkm3S1oo6eWSrpb0I2BNNt8/S7oru3wwmzZe0m+z371L0uuz6V+Q9L+S7pQ0ap8UJDjxDU9y+DGP8b0L03qRd9BGHfXP3q6jng7ackxktvMiivyp9Wdc3fJDdqmZldvaNozwGrek/YHTgH2z57oduC27e1JEvCybbzJwcESEpHcAHwM+DNwAvBR4CLgfOBz4IXAw8J4+nvIi4AsRcamkOkpvTLOBA4G9IuKBLNMZwEGAgJuyN5AFwLqIODbLNFHSFOAkYM8s26RhXDwD+sMvpzNj12rWt3RzwmlPsmj3ag47OK2zeJuNJVKBQ6ecQmexg1Ubr2BTVysTqqfkkmWk17gPBy6NiK0RsRFY3uu+n/a6vhtwuaQ1wEeBJdn0FcAR2eVcYG9Js4DWiOd+1pI0AZgVEZcCRER7RGzN7r45Ih7Irh+WZdqSPcYvspxrgKMk/aekwyPiGWAj0A58V9LJwFb6IOlMSbdKurXlqeEZiZmxa+k9dWpzFce/qp7bVm8blscdDbXU095rDbudNmp7rYGbpaymUMuUmhm0bHsktwyjsTlg9DN9S6/r5wDfjIi9gXcBPauW11Eq1cOBa4D1wCmUCh1J35e0WtLvKK0996f3c/U5X0TcB+xPqcA/L+lT2dj7gcDPgROBy/r53fMiYllELGvepaqvWYZky9YimzYXn71+5bXtvHhxGuPbAE1Mpo3NtMUWilHkCR5hKjPyjmW2w7YV2+gsdgClLUye2raW8VWj9gF8OyP95eR1wPmSvpA91/HAd/qYbyKwNrv+lp6JEfGIpGZgXETcL+l64CPAWdn9Z/R+EEmPSjoxIn4pqRboq0V7ZxKloZDTJc2ktCZ/oaTNwFslNQINEfE7SSuBv+7oghiKJ9cXeePb1wPQ1Q2nntjAPx5Zz/Lfb+Wjn9xAS2s3p/zTevZZMo5f/mjaaEQakoIKLI6lrGIFQTCTeTRqYt6xBnVn1w1sKD5BJx1ct+1SFlbtw6yqhXnHGpAzj46O4lbWbLqaiACC6bULmVY7N7c8I1rcEXG7pJ8CqymNU6/oZ9azgUskrQVWAvN73XcTfy/gFcDngev7eZzTge9I+jTQCbyun0znAzdnk74bEaskHQ18SVIx+933ABOAX2Xj5QI+NOgfPQzmz63mxj9uv4Z6wqsaOOFVDaMRYac1awbNia1l71P90rwjDJkzj44J1btw6ORT8o7xLJXeQWy47PeS2rju97vmHWNITtrtwLwj7BDVjMs7glWwwsQJeUcYkhs3/JxnOtcPNOT7LO/ybmaWGBe3mVliXNxmZolxcZuZJcbFbWaWGBe3mVliXNxmZolxcZuZJcbFbWaWGBe3mVliXNxmZolxcZuZJcbFbWaWGBe3mVliXNxmZolxcZuZJcbFbWaWmJE+5+QLzl/vHJ/cGWUuX7c67wg75OiZS/OOMGQpnrUnOrflHWGHFJ/ZlHeEIYnuYtnzeo3bzCwxLm4zs8S4uM3MEuPiNjNLjIvbzCwxLm4zs8S4uM3MEuPiNjNLjIvbzCwxLm4zs8S4uM3MEuPiNjNLjIvbzCwxLm4zs8S4uM3MEuPiNjNLjIvbzCwxLm4zs8T41GUJaInHuY/VBMEs5jNPe+YdqU8LDniQCY0FqqqgukrcfPlsPvbpFn5zxRbGjRML5tbwva9NY9LEqryj9imV5dzb3V0rWV9cyzjVcWjNsXnHKZuX9c7xGvcgJD0oqTm7vnm0nz8iuJdVLOUwDuFoHucRNsfG0Y5Rtit/Novb/ziHmy+fDcBRRzRw5zVzWH3VHBYtrOEL52zIOWHfUlvOPWYWFrBf9ZF5xxgSL+ud5+IGVFKRy+IZWqmnkQY1UlCB6cxmPevyjlW2V768gepqAXDQfnU8uq4r50R9S3U5Ty5Mo0ZpnYDYy3rnVWRZjQZJ8yT9WdK3gNuB0yWtkXSXpP/MO1+PDtqoo/7Z23XU00Fbjon6J8Exp63jgFc+wnkXPLPd/d//yUaOecX4HJINLqXlnDov6533Qh/jXgycAXwWWAnsD2wArpB0YkT8spwHkXQmcCZAHQ0jFLXyrVi+GzN3rebJli6Ofv069tx9HEccUvoP+rmvtVJdJd702sacU5ql7wW7xp15KCJWAgcA10TE+ojoAi4Cjij3QSLivIhYFhHLaqgd1oC11NPea22knTZqe62tVJKZu5bWA6Y1V3Piq8Zzy+p2AH5w8UZ++8ctXPjf05GUZ8R+pbScU+dlvfNe6MW9JftZmW0CNDGZNjbTFlsoRpEneISpzMg71na2bC2yaXPx2et/uLaNJYvHcdlVW/jSNzfwy/Nn0tBQuS+3VJbzWOBlvfNe6EMlPW4Cvp5tPbIBeANwTr6RSgoqsDiWsooVBMFM5tGoiXnH2s4T67t57dseA6CrC95wUiPHvGI8iw55iI5twdGnrQVKX1Ce+8VpeUbtUyrL+fnu7LqBDcUn6KSD67ZdysKqfZhVtTDvWAPyst55Lm4gIh6T9C/A1ZTWvn8XEb/KOdazmjWD5gpfI1kwt4ZVV87Zbvp9N87NIc2OSWE5P98+1S/NO8IO8bLeOS/Y4o6IB4G9et3+EfCjPuab1+u6v1kzs9xV7qCjmZn1ycVtZpYYF7eZWWJc3GZmiXFxm5klxsVtZpYYF7eZWWJc3GZmiXFxm5klxsVtZpYYF7eZWWJc3GZmiXFxm5klxsVtZpYYF7eZWWJc3GZmiXFxm5kl5gV7Bhz7u2PmHph3hB3S9cdd844wZNVHPZx3hBeM6NyWd4ShiSh7Vq9xm5klxsVtZpYYF7eZWWJc3GZmiXFxm5klxsVtZpYYF7eZWWJc3GZmiXFxm5klxsVtZpYYF7eZWWJc3GZmiXFxm5klxsVtZpYYF7eZWWJc3GZmiXFxm5klxmfASUBLPM59rCYIZjGfedoz70gDurtrJeuLaxmnOg6tOTbvOP3q3tbF6g/+lGJnN9EdTD1iD+a/9VAigge+dwPrr70PVRWYefw+7HbyfnnH7Vdqrw9w5p01asUt6Wxgc0R8eRSfcybwjYg4ZQi/cz7wm4j42YgFG4KI4F5WsS+HU0cDN3MlzTGTRjXlHa1fMwsLmF1YxF3dN+YdZUCFmipe8pXXUV0/jmJXN6s+8FOmHDiPrQ+30rF+EweefwYqiG0btuYdtV8pvj6ceeflOlQiaUTfOCJiXV+lPdLPO5yeoZV6GmlQIwUVmM5s1rMu71gDmlyYRo3G5R1jUJKori/ljK4i0VVEEuuW38Hc0w9GBQEwbnJDnjEHlOLrw5l33ogWt6RPSLpX0h+Bxdm0ayR9TtK1wAckHS/pJkmrJP1R0vRsvjWSJqnkKUn/lE2/QNJRfTzX7tnv3yHpdkkLJc2TdFd2/1slXSLp18AV2bSPZc9zh6Qv9PGY+0u6VtJtki6XNGPEFlY/Omijjvpnb9dRTwdtox1jzIruIreceQE3vPbbTN5/Dk0vmkHbumdYf8193Pqei7jz479g66Mb8o7ZrxRfH86880asuCXtD5wG7AucDBzQ6+5JEfGyiPgKcD1wcETsC/wE+Fg2zw3AS4ElwP3A4dn0g4GVfTzlRcB/R8RLgEOBx/qY5xDgLRHxCkmvAk4EDsp+54vPy18DnAOcEhH7A98D/qOfv/VMSbdKurWTjn6XiVUeVRU44LzTOeSn72TTPY+z+YEWip3dFGqqWHbum5hx7N7c+6Ur8o5p9hwjOWRwOHBpRGwFkLS8130/7XV9N+Cn2drsOOCBbPoK4AjgIeBc4ExJs4DWiNjc+4kkTQBmRcSlABHRnk1/fqY/RERrdv0o4Ps9+XpN77EY2Av4Q/Y4VfT9ZkBEnAecB9CkKdHXPDuqlnrae72zt9NGba93fhseNY11TFo6m9ZbHqR2aiPNR+wBQPNhu3PPly7POV3/Unx9OPPOG3CNW9KvJS3v71LG4/dXYlt6XT8H+GZE7A28C6jLpl9HqfwPB64B1gOnUCp0JH1f0mpJvwO2a+gynlcD5Ou5/+6IWJpd9o6IV5b5PMOmicm0sZm22EIxijzBI0xl1EdsxqRtT2+lc3M7AN0dnWy47WEaZk+h+aW78/SqRwB4+o5Hadhtcp4xB5Ti68OZd95ga9w9W4CcDOwKXJjdfgPw4CC/ex1wfjZ2XA0cD3ynj/kmAmuz62/pmRgRj0hqBsZFxP2Srgc+ApyV3X9G7weR9KikEyPil5JqKa0hD+QK4FOSfhQRWyVNed5a973AVEmHRMSN2dDJooi4e5DHHVYFFVgcS1nFCoJgJvNo1MTRjDBkd3bdwIbiE3TSwXXbLmVh1T7MqlqYd6ztbHtqC/d88TKiO4gIpr1sEc2HLGDi3jP58+d+z6M/v42qunEs/vCov1+XLcXXhzPvvAGLOyKuBZD0mYg4otddv5Z03SC/e7uknwKrKQ13rOhn1rOBSyStpTR2Pb/XfTfx9wJeAXye0ph4X04HviPp00An8DqgOEC+yyQtBW6VtA34HfCvve7fJukU4BuSJlJaVl8DRrW4AZo1g+YKXyPpbZ/ql+YdoSyNC6ey7Dunbze9prGOfT53Ug6Jdkxqrw9w5p2liMGHZCX9GTg2Iu7Pbs8HfhcRLxrhfMlp0pQ4SP+Qd4whUU3lb7rXl87f75p3hCGrPurhvCNYhboprmRjtJY17Fvul5MfAq6RdH92ex6l8WgzMxtlZRV3NqywB9Czj+c9EeHt3szMclDWdtySGoCPAmdFxB3AHEnHjWgyMzPrU7k74Hwf2EZpBxaAR4HPjkgiMzMbULnFvTAivkhpaw0ioo3yt502M7NhVG5xb5NUT7bDiqSF4H27zczyUO5WJWcDlwGzJV1E6RgiZwz4G2ZmNiLK3arkCkm3UTrAk4APRETLiCYzM7M+lbtVyZUR8VRE/DYifhMRLZKuHOlwZma2vQHXuCXVAQ1As6TJ/P0LySZg5ghnMzOzPgw2VPIu4IOUSvo2/l7cG4H/HsFcZmbWj8EOMvV14OuS3hcR54xSJjMzG0C5mwMWJU3quSFpsqT3jlAmMzMbQLnF/c6IeLrnRkRsAN45MpHMzGwg5RZ3Qb3OAyapitJpxszMbJSVuwPO5cDFkr5Nae/Jd1PaIcfMzEZZucX9fyltYfIeSluWXAF8d6RCmZlZ/8rdc7JI6Uzr545sHMuD6mrzjrBDUjybzH3fXZZ3hCHb80P35h1hhxQ3bco7wogZbAeciyPiVElr6OOM6BGxz4glMzOzPg22xv2B7KdPmmBmViEG2wHnseznQ6MTx8zMBjPYUMkm+hgi6RERTcOeyMzMBjTYGvcEAEmfBh4HLqC0VcmbgAkjns7MzLZT7g44R0fEtyJiU0RsjIhzgdeOZDAzM+tbucXdLelNkqokFSS9CegeyWBmZta3cov7jcCpwBPZ5XXZNDMzG2Xl7oDzIPCakY1iZmblKPfUZYskXSnpruz2PpI+ObLRzMysL+UOlfw/4F+AToCIuBM4baRCmZlZ/8ot7oaIuPl507qGO4yZmQ2u3OJukbSQbGccSacAj41YKjMz61e5h3X9P8B5wJ6S1gIPUNoJx8zMRtmgxS2pACyLiKMkjQcKETF2j5doZlbhBh0qyY7FfVZ2fYtL28wsX+WOcf9B0kckzZY0pecyosnMzKxP5Y5xv43SF5Pvfd70BcMbx/rSEo9zH6sJglnMZ572zDvSgNqLm1nTtoJt0QaI3WoWMbd2Sd6xBpXCcu5qfZqnvnsx3Rs3IYnxRxxI0z8exrZH1tH6w18SHR1UNU+m+Z2nUaivyztun/z62HnlFveLKZX2YZQKfAXw7ZEKNVwkvZ/SeTKbgEsj4qycIw1ZRHAvq9iXw6mjgZu5kuaYSaMq94i6osDiugNoqmqmKzpZuWU5u1TPorFqUt7R+pXKclahwOTXH8u4ubMotnXw+GfOoX7JHrSe/wsmnfpq6hYvYPOKW9h42XVMOumVecftk18fO6/coZIfAC8CvgGck13/wUiFGkbvBV4NfCLvIDvqGVqpp5EGNVJQgenMZj3r8o41oNpCA01VzQBUq4bxhYl0xJacUw0sleVcNamJcXNnAVCor6VmxlS6Nmyk8/H11C6aD0Ddkj3YettdecYckF8fO6/c4l4cEe+IiKuzy5nA4pEMtrMkfZvSUM5yYHKv6XOz3ffvzH7Oyaa/TtJdku6QdF02bYmkmyWtzubfY7T/jg7aqKP+2dt11NNB22jH2GFtxU1s6m5lYtXUvKMMKMXl3NXSyraH11G7YDY1s6bTtvp/Adh6yxq6W5/OOV15/PrYMeUW9ypJB/fckHQQcMPIRBoeEfFuYB1wJLCh113fBH6Ynej4IkqfIgA+Rem44y8BTsimvRv4ekQsBZYBj45G9rGiKzpZvfVqFtcdSLXG5R1nTCm2d7D+Wxcx+bTjKdTXscsZp7D5qpU89ulziPYOVF3uKGh+/PrYceX+6x4E/JOkh7Pbc4A/95z9PbGzvR8CnJxdvwD4Ynb9BuB8SRcDv8im3Qh8QtJuwC8i4i80e5KJAAAOzElEQVR9PaCkM4EzAepoGNawtdTT3uudvZ02anu981eqYhS5Y+tVzKhZwPSaeXnHGVRKyzm6umn51oWMP2gpDfvvBUDNjGlM+/DbAeh8fD1ta+7JM+Kg/PrYOeUW9zEjmiJfAaU19OyTxLHAaklLI+JHkm7Kpl0u6R0RcdV2DxBxHqU9S2nSlH7P0bkjmphMG5tpiy3UUs8TPMJeHDicTzHsIoK7269nfNUk5tXulXecsqSynCOCp87/GTUzptF09OHPTu/euJmqpkaiWOSZ31xF48sOyjHlwPz62HnlHo97LJ3l/U+Ujmx4AaXd9q8HkLQwIm4CbpJ0PDBb0kTg/oj4hqQFwD7AdsU9kgoqsDiWsooVBMFM5tGoiaMZYcie7n6Sxzr/RmNhMjdu/hUAu9fux9Sa2Tkn618qy7njrw+x9cZV1Oy2K4+d/XUAJp18NJ1PtLD56pUANOy3hPGHLcsz5oD8+th5ihjWFcSKIulBSmPTx1Habf8sSfOA7wHNwHrgjIh4WNIvgD0onQz5SuCDwMeBN1M6nO3jwBsjonWg52zSlDhI/zAif89IKUxI87zPxU3p7cR733crt1D7s+eH7s07wg5J7fVxU1zJxmhVOfNW/jcYOyEi5mVXz88uPWfzeUUf8578/GnA57OLmVnFKHerEjMzqxAubjOzxLi4zcwS4+I2M0uMi9vMLDEubjOzxLi4zcwS4+I2M0uMi9vMLDEubjOzxLi4zcwS4+I2M0uMi9vMLDEubjOzxLi4zcwS4+I2M0uMi9vMLDFj+gw4Vp7UTvHUQzXj8o4wZCmeBuyery7OO8IOWfSOW/OOMGK8xm1mlhgXt5lZYlzcZmaJcXGbmSXGxW1mlhgXt5lZYlzcZmaJcXGbmSXGxW1mlhgXt5lZYlzcZmaJcXGbmSXGxW1mlhgXt5lZYlzcZmaJcXGbmSXGxW1mlhifAScBLfE497GaIJjFfOZpz7wjDSrFzHd3rWR9cS3jVMehNcfmHacs7cXNrGlbwbZoA8RuNYuYW7sk71jb6Wp9mqe+ezHdGzchifFHHEjTPx7GtkfW0frDXxIdHVQ1T6b5nadRqK/LO26fKuk1PeaKW9L7gfcAt0fEm/LOs7MigntZxb4cTh0N3MyVNMdMGtWUd7R+pZgZYGZhAbMLi7ir+8a8o5RNFFhcdwBNVc10RScrtyxnl+pZNFZNyjvac6hQYPLrj2Xc3FkU2zp4/DPnUL9kD1rP/wWTTn01dYsXsHnFLWy87DomnfTKvONup9Je02NxqOS9wKtHorQljfob3TO0Uk8jDWqkoALTmc161o12jCFJMTPA5MI0apTWeSxrCw00VTUDUK0axhcm0hFbck61vapJTYybOwuAQn0tNTOm0rVhI52Pr6d20XwA6pbswdbb7sozZr8q7TU9popb0reBBcBySZ+Q9D1Jt0haJek12Tw3SVrS63eukbS/pPH9zP9WSZdI+jVwxWj/TR20UUf9s7frqKeDttGOMSQpZh4L2oqb2NTdysSqqXlHGVBXSyvbHl5H7YLZ1MyaTtvq/wVg6y1r6G59Oud0fau01/SYKu6IeDewDjgSGA9cFREHZLe/JGk88BPgVABJM4CZEXEb8Il+5gc4BHhLRLxiVP8gszJ1RSert17N4roDqa7gTw3F9g7Wf+siJp92PIX6OnY54xQ2X7WSxz59DtHegarH3OjtiBjLS+mVwAmSPpLdrgPmABcDfwD+jVKBXzLI/AB/iIjW/p5I0pnAmaVfahjOv4Fa6mnv9c7eThu1vd75K1GKmVNWjCJ3bL2KGTULmF4zL+84/Yqublq+dSHjD1pKw/57AVAzYxrTPvx2ADofX0/bmnvyjNivSntNj6k17ucR8NqIWJpd5kTEnyNiLfCUpH2A11NaA+93/uy+AQcNI+K8iFgWEctqqB3WP6KJybSxmbbYQjGKPMEjTGXGsD7HcEsxc6oigrvbr2d81STm1e6Vd5x+RQRPnf8zamZMo+now5+d3r1xc+n+YpFnfnMVjS87KK+IA6q01/RYXuO+HHifpPdFREjaNyJWZff9BPgYMDEi1pQxf24KKrA4lrKKFQTBTObRqIl5xxpQipkB7uy6gQ3FJ+ikg+u2XcrCqn2YVbUw71gDerr7SR7r/BuNhcncuPlXAOxeux9Ta2bnnOy5Ov76EFtvXEXNbrvy2NlfB2DSyUfT+UQLm69eCUDDfksYf9iyPGP2q9Je04qI3J58JEh6EFhGaS35a8ChlNamH4yI47J5pgNrgc9ExL9n0+r7ml/SW4FlEXFWOc/fpClxkP5hWP8m65tqKncstz+qG95PZKPhnq8uzjvCDln0jlvzjjAkN8WVbIxWlTPvmFvjjoh5vW6+q595nuB5f3tEtPU1f0ScD5w/bAHNzHbSWB7jNjMbk1zcZmaJcXGbmSXGxW1mlhgXt5lZYlzcZmaJcXGbmSXGxW1mlhgXt5lZYlzcZmaJcXGbmSXGxW1mlhgXt5lZYlzcZmaJcXGbmSXGxW1mlhgXt5lZYlzcZmaJGXOnLsubCgUKjRPyjjEkqk3v3I0A3S1P5R1hyKJzW94Rhiy1czf2+OtXD847wpB0fGVl2fN6jdvMLDEubjOzxLi4zcwS4+I2M0uMi9vMLDEubjOzxLi4zcwS4+I2M0uMi9vMLDEubjOzxLi4zcwS4+I2M0uMi9vMLDEubjOzxLi4zcwS4+I2M0uMi9vMLDE+A06Fay9uZk3bCrZFGyB2q1nE3NoleccaUHd0cfPTyylGN0Gwa+18dh9/QN6xBtUSj3MfqwmCWcxnnvbMO1JZUsydQuauDU/TctGP6d64CQpiwiEH0/SywwHYeN31bFxxA6oqUP/iFzHlhONGNduYLG5JDwLLIqKlzPnfms1/1kjm2hGiwOK6A2iqaqYrOlm5ZTm7VM+isWpS3tH6VaCKAyYdT7VqKEY3Nz+9nOZxc5hUMz3vaP2KCO5lFftyOHU0cDNX0hwzaVRT3tEGlGLuZDIXCkx+zfHUzt6NYns7677yNeoW70H3ps1svetuZv3fD6Pqaro3bRr9aKP+jDYktYUGmqqaAahWDeMLE+mILTmnGpgkqlUDQFCkSDHnRIN7hlbqaaRBjRRUYDqzWc+6vGMNKsXcqWSunthE7ezdACjU1VEzfTrdz2xk0w1/YuI/HImqS+u9VRNG/xyzyRe3pPGSfivpDkl3SXp9dtf7JN0uaY1U+hwm6UBJf5K0Kvu5uI/HO1bSjZKaJU2V9HNJt2SXl47qH/c8bcVNbOpuZWLV1DxjlCWiyJ9af8bVLT9kl5pZFb22DdBBG3XUP3u7jno6aMsxUXlSzJ1i5s6nWtn26Fpq586h88kW2u9/gHX/9XUeO+dbdDz88KjnSb64gWOAdRHxkojYC7gsm94SEfsB5wIfyabdAxwREfsCnwI+1/uBJJ0EfBx4dTbM8nXgqxFxAPBa4Lt9BZB0pqRbJd26LdqH+c8r6YpOVm+9msV1B1Ktyj8ru1Tg0Cmn8LJd3swzXevZ1NWadySzHVLs6GD993/AlJNeQ6GuDordFLe2MeND72fKCcex/vwLiIhRzTQWxrjXAF+W9J/AbyJihSSAX2T33wacnF2fCPxA0h5AADW9HudIYBnwyojYmE07Cnhx9ngATZImRMRzBrUi4jzgPICJVc3D/i9YjCJ3bL2KGTULmF4zb7gffkTVFGqZUjODlm2PMKF6St5x+lVLPe291vraaaO211phpUoxd0qZo7ubJ7/3A8bvvx/jX7I3AFWTJtGwz15IonbuHFCB4pYtVDU2jlqu5Ne4I+I+YH9KBf55SZ/K7urIfnbz9zeozwBXZ2vmxwN1vR7qfmACsKjXtAJwSEQszS6znl/aIy0iuLv9esZXTWJe7V6j+dQ7bFuxjc5iafF3RxdPbVvL+Ar+MhWgicm0sZm22EIxijzBI0xlRt6xBpVi7lQyRwQtP76YmunTmXjky56d3rD3Etr/8lcAOp9cT3R3URg/flSzJb/GLWkm0BoRF0raDLx1gNknAmuz68+f7yFKQyqXSnpdRNwNXAGcBXwpe66lEbF6GOMP6unuJ3ms8280FiZz4+ZfAbB77X5MrZk9mjGGpKO4lTWbrs4+PgbTaxcyrXZu3rEGVFCBxbGUVawgCGYyj0ZNzDvWoFLMnUrmjgceZMutt1EzYwZrv/hfAEw+7lVMOOhAWn58MWu/8CVUXU3zG0+j16fyUaHRHpsZbpKOplSsRaATeA/wM7LNASUtA74cES+XdAjwA2A9cBVwekTM6705oKR9gYsorZE/A/w38CJKb3LXRcS7B8ozsao5Dm48YST+1BGj2sofM+9Ld8tTeUewCvbXrx6cd4QhWfeVr9Hx8CNlvQMkX9yVxsU9elzcNpCxXNzJj3Gbmb3QuLjNzBLj4jYzS4yL28wsMS5uM7PEuLjNzBLj4jYzS4yL28wsMS5uM7PEuLjNzBLj4jYzS4yL28wsMS5uM7PEuLjNzBLj4jYzS4yL28wsMS5uM7PE+Aw4w0zSekrnrxxuzUDLCDzuSEsxtzOPjhQzw8jlnhsRU8uZ0cWdCEm3RsSyvHMMVYq5nXl0pJgZKiO3h0rMzBLj4jYzS4yLOx3n5R1gB6WYe0iZJU2S9N6RClOmMb+cK0juuT3GbbaTJM0DfhMRez1velVEdOcSysY0r3Gb7bwvAAslrZZ0i6SrJf0IWCNpnqS7emaU9BFJZ2fXF0q6TNJtklZI2jOn/JaY6rwDmI0BHwf2ioilkl4O/Da7/UC2Nt6f84B3R8RfJB0EfAt4xUiHtfS5uM2G380R8cBAM0hqBA4FLpHUM7l2pIPZ2ODiNht+W3pd7+K5Q5J12c8C8HRELB21VDZmeIzbbOdtAib0c98TwDRJu0iqBY4DiIiNwAOSXgegkpeMSlpLnte4zXZSRDwl6YbsS8g2SmXdc1+npE8DNwEPAPf0+tU3AedK+iRQA/wEuGP0kluqvDmgmVliPFRiZpYYF7eZWWJc3GZmiXFxm5klxsVtZpYYF7eZWWJc3GZmiXFxm5kl5v8H0NBQq5QhhfkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 360x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "y_hat = model_1.predict(test_df.drop('label', axis=1))\n",
+    "y_hat = y_hat.argmax(axis=1)\n",
+    "y_hat = label_encoder.inverse_transform(y_hat)\n",
+    "\n",
+    "fig = plt.figure(figsize=(5,5))\n",
+    "ax = plt.subplot()\n",
+    "\n",
+    "labels = list(test_df['label'].value_counts().index)\n",
+    "\n",
+    "confusion = confusion_matrix(test_label, y_hat, labels=labels)\n",
+    "ax.matshow(confusion)\n",
+    "\n",
+    "ax.set_xticks(range(len(labels)))\n",
+    "ax.set_yticks(range(len(labels)))\n",
+    "\n",
+    "ax.set_xticklabels(labels, rotation=90);\n",
+    "ax.set_yticklabels(labels);\n",
+    "\n",
+    "for i in range(len(labels)):\n",
+    "    for j in range(len(labels)):        \n",
+    "        ax.text(j, i, confusion[i,j], va='center', ha='center')\n",
+    "        \n",
+    "plt.xlabel('true')\n",
+    "plt.ylabel('predicted')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "  draw-cross       0.96      0.89      0.93        57\n",
+      "        roll       0.90      0.96      0.93        54\n",
+      " draw-circle       0.95      0.97      0.96        37\n",
+      "       floss       0.88      0.88      0.88        33\n",
+      "       fever       0.91      0.91      0.91        32\n",
+      "       shake       0.87      0.84      0.85        31\n",
+      "\n",
+      "   micro avg       0.91      0.91      0.91       244\n",
+      "   macro avg       0.91      0.91      0.91       244\n",
+      "weighted avg       0.91      0.91      0.91       244\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(classification_report(test_label, y_hat, labels=labels))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save = True\n",
+    "ver = int(dt.now().timestamp())\n",
+    "\n",
+    "if save:\n",
+    "    for fmt in ['pb', 'hdf5', 'json']:\n",
+    "        # save model as hdf5\n",
+    "        MODEL_DIR = f\"models/{fmt}\"\n",
+    "        export_path = Path(MODEL_DIR, str(ver))\n",
+    "\n",
+    "        if fmt == 'pb':\n",
+    "            # simple_save can not handle existing repository\n",
+    "            !rm -r {export_path}\n",
+    "\n",
+    "            # Inspired by https://www.tensorflow.org/serving/tutorials/Serving_REST_simple\n",
+    "            # to save model for TF-serving\n",
+    "            tf.saved_model.simple_save(\n",
+    "                tf.keras.backend.get_session(),\n",
+    "                str(export_path),\n",
+    "                inputs={'input_data': model_1.input},\n",
+    "                outputs={t.name:t for t in model_1.outputs})\n",
+    "            \n",
+    "        elif fmt == 'hdf5':\n",
+    "            # make sure directory exists\n",
+    "            os.makedirs(export_path, exist_ok=True)\n",
+    "            \n",
+    "            model_path = Path(export_path, 'saved_model.h5') \n",
+    "            \n",
+    "            # hdf5\n",
+    "            model_1.save(model_path)\n",
+    "            \n",
+    "        else:\n",
+    "            # make sure directory exists\n",
+    "            os.makedirs(export_path, exist_ok=True)\n",
+    "            \n",
+    "            # json\n",
+    "            model_spec_path = Path(\n",
+    "                export_path, 'saved_model_spec.json'\n",
+    "            )\n",
+    "            model_weights_path = Path(\n",
+    "                export_path, 'checkpoint')\n",
+    "            \n",
+    "            model_spec_path.write_text(model_1.to_json(), encoding='utf-8')\n",
+    "            model_1.save_weights(str(model_weights_path))\n",
+    "\n",
+    "        print('\\nSaved model:')\n",
+    "        !ls -l {export_path}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "TF",
+   "language": "python",
+   "name": "tf"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adapts the work done by @TreeinRandomForest and includes a TensorFlow feed forward network for training a gesture recognition model on all six gestures (replacing "draw-traingle" with "draw-cross") that achieves ~90% accuracy on the test set.

This notebook also saves the model for serving.

This has been tested on the OCP4 demo cluster (as of today) and should run end-to-end without issue.  

    