### PR TITLE
Have to unset APP_FILE for OpenShift to use gunicorn

### DIFF
--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,3 +1,2 @@
-APP_FILE=./v5_Gesture_Recognition_Serving.py
 ENABLE_PIPENV=1
 WEB_CONCURRENCY=4


### PR DESCRIPTION
I missed this in my last PR because I only tested this locally. I've now run this through a full OpenShift Build and can confirm the pods now use gunicorn instead of the flask dev server with this unset.